### PR TITLE
Rename the sftp connector package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "connectors/sftp",
+  "name": "workivate/sftp",
   "description": "SftpConnecter for Porter.",
   "authors": [
     {


### PR DESCRIPTION
https://workivate.atlassian.net/browse/LT-4497. Jenkins build try to connect to the old package that has either moved/removed by the author or has been made private. This package now will have to be included in the wa-api composer.json file.